### PR TITLE
escape characters in xml document

### DIFF
--- a/index.lua
+++ b/index.lua
@@ -20,6 +20,16 @@ local xmlEnd = [[
 </tv>
 ]]
 
+local function stringifyXml(str)
+	if not str then return "" end --// if this is somehow not a string
+
+	return str:gsub("&", "&amp;") --// technically, only "&" and "<" are required to be escaped....but why not escape all of these characters anyway: no harm in doing so!
+		:gsub("<", "&lt;")
+		:gsub(">", "&gt;")
+		:gsub('"', "&quot;")
+		:gsub("'", "&apos;")
+end
+
 local function convertUnixToDate(timestamp)
 	local year = os.date("%Y",timestamp)
 	local month = os.date("%m",timestamp)
@@ -38,10 +48,10 @@ local function generate()
 	local finalXml = xmlBase
 
 	--// now playing
-	finalXml = finalXml..'<programme channel="LapFoxRadio" start="'..convertUnixToDate(tablifiedContent.now_playing.played_at)..' +0000" stop="'..convertUnixToDate(tablifiedContent.now_playing.played_at+tablifiedContent.now_playing.duration)..' +0000"> <title lang="en">'..tablifiedContent.now_playing.song.text..'</title> <icon src="'..tablifiedContent.now_playing.song.art..'"/> </programme>'
+	finalXml = finalXml..'<programme channel="LapFoxRadio" start="'..convertUnixToDate(tablifiedContent.now_playing.played_at)..' +0000" stop="'..convertUnixToDate(tablifiedContent.now_playing.played_at+tablifiedContent.now_playing.duration)..' +0000"> <title lang="en">'..stringifyXml(tablifiedContent.now_playing.song.text)..'</title> <icon src="'..stringifyXml(tablifiedContent.now_playing.song.art)..'"/> </programme>'
 
 	--// playing next
-	finalXml = finalXml..'<programme channel="LapFoxRadio" start="'..convertUnixToDate(tablifiedContent.playing_next.played_at)..' +0000" stop="'..convertUnixToDate(tablifiedContent.playing_next.played_at+tablifiedContent.playing_next.duration)..' +0000"> <title lang="en">'..tablifiedContent.playing_next.song.text..'</title> <icon src="'..tablifiedContent.playing_next.song.art..'"/> </programme>'
+	finalXml = finalXml..'<programme channel="LapFoxRadio" start="'..convertUnixToDate(tablifiedContent.playing_next.played_at)..' +0000" stop="'..convertUnixToDate(tablifiedContent.playing_next.played_at+tablifiedContent.playing_next.duration)..' +0000"> <title lang="en">'..stringifyXml(tablifiedContent.playing_next.song.text)..'</title> <icon src="'..stringifyXml(tablifiedContent.playing_next.song.art)..'"/> </programme>'
 
 	--// close xml
 	finalXml = finalXml..xmlEnd


### PR DESCRIPTION
### why?
when the `title` or `icon` values contain invalid xml characters ("`<` and "`&`"), the returned xml document will be invalid (as shown below)
![image](https://github.com/user-attachments/assets/ae020a02-510c-4278-9f1b-abe52b67087b)
we can't control if these characters are pre-sanitised for xml as they're [returned by the api](https://radio.lapfoxradio.com/api/nowplaying/lapfox_radio)

### what this pull request is
this kewl code escapes all occurrences of these invalid xml characters from the api
..as well as the other three xml escape characters ("`"`", "`'`", and "`>`") because why not

### example
below are screenshots of the working example~
![image](https://github.com/user-attachments/assets/bb2bb777-fc9f-4767-a309-8cdd9c1cc862)
![image](https://github.com/user-attachments/assets/858282f2-484f-49a2-be93-4b30e0e31890)
